### PR TITLE
Derive public keys from private keys

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
@@ -11,6 +11,7 @@
 package org.dpppt.backend.sdk.ws.config;
 
 import java.security.KeyPair;
+import java.security.PrivateKey;
 import java.util.List;
 
 import javax.sql.DataSource;
@@ -81,9 +82,6 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 	@Value("${ws.app.source}")
 	String appSource;
 	
-	@Value("${ws.app.response.publickey}")
-	String responsePublicKey;
-	
 	@Value("${ws.app.response.privatekey}")
 	String responsePrivateKey;
 
@@ -142,8 +140,8 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 	}
 
 	public KeyPair getKeyPair(SignatureAlgorithm algorithm) throws Exception{
-		logger.warn("USING FALLBACK KEYPAIR. WONT'T PERSIST APP RESTART AND PROBABLY DOES NOT HAVE ENOUGH ENTROPY.");
-		return new KeyPair(KeyHelper.getPublickKey(responsePublicKey), KeyHelper.getPrivateKey(responsePrivateKey));
+		PrivateKey key = KeyHelper.getPrivateKey(responsePrivateKey);
+		return new KeyPair(KeyHelper.extractPublicKey(key), key);
 	}
 
 	@Override

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -21,6 +21,7 @@ import org.dpppt.backend.sdk.ws.security.OTPKeyGenerator;
 import org.dpppt.backend.sdk.ws.security.OTPManager;
 import org.dpppt.backend.sdk.ws.security.ValidateRequest;
 import org.dpppt.backend.sdk.ws.security.ValidateRequest.InvalidDateException;
+import org.dpppt.backend.sdk.ws.util.KeyHelper;
 import org.dpppt.backend.sdk.ws.util.ValidationTypeEnum;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -270,7 +271,8 @@ public class DPPPTController {
 		
 		try {
 			OTPManager.getInstance().checkPassword(authorizationCode, expiredTime);
-			JWTGenerator jwtGenerator = new JWTGenerator(jwtPrivate);
+			// FIXME: perform getPrivateKey once, at WSBaseConfig, don't read key on every request
+			JWTGenerator jwtGenerator = new JWTGenerator(KeyHelper.getPrivateKey(jwtPrivate));
 			OffsetDateTime expiresAt = OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusYears(1);
 			String jwtToken = jwtGenerator.createToken(expiresAt, fake);
 			onSetResponse.setAccessToken(jwtToken);

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/security/FrontalSecurityService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/security/FrontalSecurityService.java
@@ -7,6 +7,8 @@ import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.Map;
 
+import org.dpppt.backend.sdk.ws.util.KeyHelper;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -77,7 +79,8 @@ public class FrontalSecurityService {
 	
 	public String generateJWTToken() throws Exception{
 		
-		JWTGenerator jwtGenerator = new JWTGenerator(jwtPrivate);
+		// FIXME: perform getPrivateKey once, at WSBaseConfig, don't read key on every request
+		JWTGenerator jwtGenerator = new JWTGenerator(KeyHelper.getPrivateKey(jwtPrivate));
 		OffsetDateTime expiresAt = OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(60);
 		String jwtToken = jwtGenerator.createToken(expiresAt, 0);
 		

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/security/JWTGenerator.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/security/JWTGenerator.java
@@ -21,9 +21,9 @@ import java.util.Date;
 import java.util.UUID;
 
 public class JWTGenerator {
-    private String privateKey;
+    private PrivateKey privateKey;
 
-    public  JWTGenerator(String privateKey) {
+    public JWTGenerator(PrivateKey privateKey) {
         this.privateKey = privateKey;
     }
 
@@ -35,13 +35,8 @@ public class JWTGenerator {
         claims.put("onset", String.valueOf(now.toLocalDate()));
         claims.put("fake", String.valueOf(fake));
 
-        String key = KeyHelper.getKey(this.privateKey);
-        PKCS8EncodedKeySpec keySpecX509 = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(key.replaceAll("\\s", "")));
-        KeyFactory kf = KeyFactory.getInstance("RSA");
-        PrivateKey privateKey = kf.generatePrivate(keySpecX509);
-
         return Jwts.builder().setClaims(claims).setId(UUID.randomUUID().toString())
                 .setSubject("test-subject" + OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toString()).setExpiration(Date.from(expiresAt.toInstant()))
-                .setIssuedAt(Date.from(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant())).signWith(privateKey).compact();
+                .setIssuedAt(Date.from(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant())).signWith(this.privateKey).compact();
     }
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/application.properties
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/application.properties
@@ -28,7 +28,6 @@ ws.exposedlist.cachecontrol=5
 ws.app.source=org.dpppt.demo
 ws.headers.protected=X-HELLO,X-BATCH-RELEASE-TIME,X-OTP
 
-ws.app.jwt.publickey=
 ws.app.jwt.privatekey=
 
 ## Configure Thymeleaf.
@@ -38,5 +37,7 @@ spring.thymeleaf.cache=false
 ## OTP Configuration
 ws.app.otp.seedKey=
 otp.min.expiration=1440
+
+ws.app.response.privatekey=
 
 back.office.user.1=


### PR DESCRIPTION
This removes two unnecessary parameters from application.properties.
Also removes obsolete warning and simplifies code a bit.