### PR TITLE
Derive public keys from private keys (v2)

### DIFF
--- a/KeysTest.java
+++ b/KeysTest.java
@@ -25,7 +25,7 @@ public class KeysTest {
 	public static void main(String[] args) throws Exception {
 		
 		KeyPair kp = Keys.keyPairFor(SignatureAlgorithm.ES256);
-		String strPrivateKey = getPrivateKeyAsPEM(kp.getPrivate());
+		String strPrivateKey = Base64.encodeToString(kp.getPrivate().getEncoded());
 		System.out.println(strPrivateKey);
 		String privateFilePath = "C:\\Users\\josevincente.marin\\Documents\\Projects\\Dp3t\\github\\dp3t-sdk-backend\\dpppt-backend-sdk\\conf_var\\keys\\privateKey.pem";
 		FileUtils.writeStringToFile(new File(privateFilePath), strPrivateKey);

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
@@ -11,6 +11,7 @@
 package org.dpppt.backend.sdk.ws.config;
 
 import java.security.KeyPair;
+import java.security.PrivateKey;
 import java.util.List;
 
 import javax.sql.DataSource;
@@ -83,9 +84,6 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 	
 	@Value("${ws.app.response.privatekey}")
 	String responsePrivateKey;
-	
-	@Value("${ws.app.response.publickey}")
-	String responsePublicKey;
 
 	@Autowired(required = false)
 	ValidateRequest requestValidator;
@@ -142,7 +140,8 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 	}
 
 	public KeyPair getKeyPair(SignatureAlgorithm algorithm) throws Exception{
-		return KeyHelper.getKeyPair(responsePrivateKey, responsePublicKey);
+		PrivateKey key = KeyHelper.getPrivateKey(responsePrivateKey, "EC");
+		return new KeyPair(KeyHelper.extractPublicKey(key), key);
 	}
 
 	@Override


### PR DESCRIPTION
Avoids the `ws.app.response.publickey` parameter.
Encodes the EC private key with only 1 base64 (like the rest of the keys).